### PR TITLE
Rely on default ConsoleRenderer constructor

### DIFF
--- a/google_structlog/setup_stdout.py
+++ b/google_structlog/setup_stdout.py
@@ -12,9 +12,7 @@ def setup_stdout_logger(
   logger.setLevel(loglevel)
 
   formatter = structlog.stdlib.ProcessorFormatter(
-    processor=structlog.dev.ConsoleRenderer(
-      colors=True
-    ),
+    processor=structlog.dev.ConsoleRenderer(),
   )
 
   handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
This change should allow the default constructor or ConsoleRenderer to
be used and determine if colors should be used of not based on the
presence of colorama as a requirement without having to add it as a
requirment for this library. Should work the same out of the box if
colorama is present but still work without it.