### PR TITLE
Pin google-cloud-logging vesion due to breaking changes in v2.0.0 released yesterday

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'google-cloud-logging',
+        'google-cloud-logging<2.0.0',
         'python-json-logger',
         'structlog'
     ],


### PR DESCRIPTION
google-cloud-logging released v2.0.0 yesterday with breaking changes: https://github.com/googleapis/python-logging/releases/tag/v2.0.0 which causes google_structlog to fail with an import error:

```
   from google.cloud.logging import _helpers
E   ImportError: cannot import name '_helpers' from 'google.cloud.logging' (<snip>/lib/python3.8/site-packages/google/cloud/logging/__init__.py)
```

We can temporarily resolve this by pinning google-cloud-logging to a pre-2.0.0 version number