### PR TITLE
Update to google-cloud-logging v2.0.0

### DIFF
--- a/google_structlog/setup_google.py
+++ b/google_structlog/setup_google.py
@@ -1,10 +1,10 @@
-from google.cloud.logging import Client
-from google.cloud.logging import _helpers
-from google.cloud.logging.handlers import CloudLoggingHandler
-from google.cloud.logging.handlers.transports.background_thread import _Worker, BackgroundThreadTransport
-from google.cloud.logging.handlers.transports.sync import SyncTransport
+from google.cloud.logging_v2 import Client
+from google.cloud.logging_v2 import _helpers
+from google.cloud.logging_v2.handlers import CloudLoggingHandler
+from google.cloud.logging_v2.handlers.transports.background_thread import _Worker, BackgroundThreadTransport
+from google.cloud.logging_v2.handlers.transports.sync import SyncTransport
 
-from google.cloud.logging.resource import Resource
+from google.cloud.logging_v2.resource import Resource
 
 from pythonjsonlogger import jsonlogger
 import structlog

--- a/google_structlog/setup_google.py
+++ b/google_structlog/setup_google.py
@@ -82,7 +82,7 @@ def get_handler(logName):
   # we found that from google.cloud.logging.handlers.transports.background_thread.BackgroundThreadTransport
   # stopped transmitting logs to GCP. We're not sure why, but as a workaround we switched to using
   # a SyncTransport sub-class.
-  handler = CloudLoggingHandler(Client(), logName, transport=StructlogTransport, **kwargs)
+  handler = CloudLoggingHandler(Client(), name=logName, transport=StructlogTransport, **kwargs)
   handler.setFormatter(jsonlogger.JsonFormatter())
   return handler
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'google-cloud-logging',
+        'google-cloud-logging>=2.0.0',
         'python-json-logger',
         'structlog'
     ],


### PR DESCRIPTION
Alternative to https://github.com/snickell/google_structlog/pull/3 which pins the dependency at <2.0.0, is to update to >=2.0.0, While the [migration guide](google.cloud.logging is an alias for google.cloud.logging_v2) says that `google.cloud.logging` is an alias for `google_cloud.logging_v2` there must be some inconsistency where it's preventing that from working, and I've found imports to work correctly when changing to `logging_v2` rather than relying on the alias.

Additionally, `CloudLoggingHandler()` [requires all optional arguments to be named](https://github.com/googleapis/python-logging/blob/master/UPGRADING.md#method-calls)

I've tested this on py3.8, and it at least doesn't error, but I'm not 100% sure it's working or is falling back to structlog. Here is a PR for your convenience